### PR TITLE
fix(doc): updated readme.md file with correct WDIO installation page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ WebdriverIO Teamcity reporter which makes it possible to display test results in
 npm install wdio-teamcity-reporter --save-dev
 ```
 
-Instructions on how to install WebdriverIO can be found here: http://webdriver.io/guide/getstarted/install.html
+Instructions on how to install WebdriverIO can be found here: https://webdriver.io/docs/gettingstarted
 
 
 ## Configuration


### PR DESCRIPTION
updated readme.md file with correct WDIO installation page URL. that is https://webdriver.io/docs/gettingstarted.

<img width="1035" alt="Screen Shot 2022-12-16 at 2 19 15 PM" src="https://user-images.githubusercontent.com/8421048/208172971-271a7f96-69cc-4aa0-b55a-366e878a7bc3.png">
